### PR TITLE
support ssl mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MySQL input plugin for Embulk loads data by binlog.
 - **user**: MySQL user (string, required)
 - **table**: MySQL user (string, required)
 - **password**: MySQL password (string, required)
+- **ssl_mode**: MySQL SSL mode. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode) for details. (string, default: `DISABLED`)
 - **from_binlog_filename**: The beginning of MySQL binlog filename (string, required)
 - **from_binlog_position**: The beginning of MySQL binlog position (integer, required)
 - **to_binlog_filename**: The end of MySQL binlog filename (string, optional) if to_binlog_filename is provided and to_binlog_position is omitted, this plugin stop fetching date just after binlog rotation to this file. if to_binlog_filename is omitted, plugin stops at the end of binlog.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Nov 05 07:23:43 JST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/org/embulk/input/mysql_binlog/MysqlBinlogClient.java
+++ b/src/main/java/org/embulk/input/mysql_binlog/MysqlBinlogClient.java
@@ -2,6 +2,7 @@ package org.embulk.input.mysql_binlog;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 import org.embulk.input.mysql_binlog.handler.*;
 import org.embulk.input.mysql_binlog.model.DbInfo;
 import org.slf4j.Logger;
@@ -25,7 +26,7 @@ public class MysqlBinlogClient implements BinaryLogClient.LifecycleListener {
     }
 
 
-    public MysqlBinlogClient(DbInfo dbInfo, String binlogFilename) {
+    public MysqlBinlogClient(DbInfo dbInfo, String binlogFilename, SSLMode sslMode) {
         client = new BinaryLogClient(dbInfo.getHost(), dbInfo.getPort(), dbInfo.getUser(), dbInfo.getPassword());
         EventDeserializer eventDeserializer = new EventDeserializer();
         eventDeserializer.setCompatibilityMode(
@@ -36,6 +37,7 @@ public class MysqlBinlogClient implements BinaryLogClient.LifecycleListener {
         client.setBlocking(false);
         client.registerLifecycleListener(this);
         client.setHeartbeatInterval(client.getKeepAliveInterval() / 2);
+        client.setSSLMode(sslMode);
     }
 
     public void registerEventListener(BinlogEventHandler binlogEventHandler) {

--- a/src/main/java/org/embulk/input/mysql_binlog/PluginTask.java
+++ b/src/main/java/org/embulk/input/mysql_binlog/PluginTask.java
@@ -1,5 +1,6 @@
 package org.embulk.input.mysql_binlog;
 
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -64,6 +65,10 @@ public interface PluginTask
     @Config("ssl")
     @ConfigDefault("\"disable\"")
     Ssl getSsl();
+
+    @Config("ssl_mode")
+    @ConfigDefault("\"DISABLED\"")
+    SSLMode getSslMode();
 
     @Config("default_timezone")
     @ConfigDefault("\"UTC\"")

--- a/src/main/java/org/embulk/input/mysql_binlog/manager/MysqlBinlogManager.java
+++ b/src/main/java/org/embulk/input/mysql_binlog/manager/MysqlBinlogManager.java
@@ -40,7 +40,7 @@ public class MysqlBinlogManager {
         this.setCurrentDdl(t.toDdl());
 
         DbInfo dbInfo = MysqlBinlogClient.convertTaskToDbInfo(task);
-        this.client = new MysqlBinlogClient(dbInfo, getBinlogFilename());
+        this.client = new MysqlBinlogClient(dbInfo, getBinlogFilename(), task.getSslMode());
         this.registerHandler();
         this.client.registerEventListener(handler);
     }


### PR DESCRIPTION
`ssl mode` is set to [`DISABLED` by default](https://github.com/osheroff/mysql-binlog-connector-java/blob/0.27.1/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java#L140) and cannot be changed.
Fixed to enable SSL.


this is the execution log when `ssl_mode: REQUIRED`  in my env.
```
$ embulk preview -I lib config.yml
2024-05-24 21:26:15.690 +0900: Embulk v0.9.26
2024-05-24 21:26:17.611 +0900 [INFO] (main): Started Embulk v0.9.26
2024-05-24 21:26:17.670 +0900 [INFO] (0001:preview): Loaded plugin embulk/input/mysql_binlog from a load path
May 24, 2024 9:26:18 PM com.github.shyiko.mysql.binlog.BinaryLogClient tryUpgradeToSSL
INFO: SSL enabled
May 24, 2024 9:26:18 PM com.github.shyiko.mysql.binlog.BinaryLogClient connect
INFO: Connected to 127.0.0.1:3307 at mysql-bin-changelog.000034/4 (cid:98)
2024-05-24 21:26:18.247 +0900 [INFO] (0001:preview): connect
2024-05-24 21:26:18.264 +0900 [INFO] (0001:preview): binlog file: mysql-bin-changelog.000034
2024-05-24 21:26:18.267 +0900 [INFO] (0001:preview): binlog file: mysql-bin-changelog.000035
2024-05-24 21:26:18.267 +0900 [INFO] (0001:preview): binlog file: mysql-bin-changelog.000035
2024-05-24 21:26:18.268 +0900 [INFO] (0001:preview): binlog file: mysql-bin-changelog.000036
2024-05-24 21:26:18.268 +0900 [INFO] (0001:preview): binlog file: mysql-bin-changelog.000036
2024-05-24 21:26:18.303 +0900 [INFO] (0001:preview): disconnect
May 24, 2024 9:26:18 PM com.github.shyiko.mysql.binlog.BinaryLogClient$5 run
INFO: threadExecutor is shut down, terminating keepalive thread
2024-05-24 21:26:18.309 +0900 [INFO] (0001:preview): disconnect
+--------+-------------------------+-----------------------+----------------+
| i:long |             t:timestamp | _test_deleted:boolean | _test_seq:long |
+--------+-------------------------+-----------------------+----------------+
|      8 | 2024-05-24 12:26:04 UTC |                 false |              1 |
+--------+-------------------------+-----------------------+----------------+
```
